### PR TITLE
Device Affinity

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <chrono>
 
-int getNodeCount(int nproc, int device_count)
+int getDevice(int nproc, int device_count)
 {
   int rank, is_rank0, nodes;
   MPI_Comm shmcomm;
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
     cudaGetDeviceCount(&count);
 
     // get the device from
-    int device = getNodeCount(nproc, count);
+    int device = getDevice(nproc, count);
 
     // set the device before calling HypreInit. 
     cudaSetDevice(device);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,24 +7,54 @@
 #include <iostream>
 #include <chrono>
 
+int getNodeCount(int nproc, int device_count)
+{
+  int rank, is_rank0, nodes;
+  MPI_Comm shmcomm;
+
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0,
+		      MPI_INFO_NULL, &shmcomm);
+  MPI_Comm_rank(shmcomm, &rank);
+  is_rank0 = (rank == 0) ? 1 : 0;
+  MPI_Allreduce(&is_rank0, &nodes, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+  MPI_Comm_free(&shmcomm);
+
+  // Here we make sure that we don't try to mod with more than the actual number of devices.
+  int ngpus_to_use = nproc/nodes;
+  ngpus_to_use = ngpus_to_use < device_count ? ngpus_to_use : device_count;
+  
+  // Here we assign device based on the rank in the shmcomm, not the global.
+  int device = rank%ngpus_to_use;
+
+  return device;
+}
+
 int main(int argc, char* argv[])
 {
-    int iproc;
+  int iproc, nproc;
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &iproc);
-
-    HYPRE_Int ret = HYPRE_Init();
+    MPI_Comm_size(MPI_COMM_WORLD, &nproc);
 
 #ifdef HAVE_CUDA
-    int count, device;
+    int count;
     cudaGetDeviceCount(&count);
-    //cudaSetDevice(iproc_ % count);
+
+    // get the device from
+    int device = getNodeCount(nproc, count);
+
+    // set the device before calling HypreInit. 
+    cudaSetDevice(device);
     cudaGetDevice(&device);
     size_t free, total;
     cudaMemGetInfo(&free, &total);
     printf("\trank=%d : %s %s %d : device=%d of %d : free memory=%1.8g GB, total memory=%1.8g GB\n",
 	   iproc,__FUNCTION__,__FILE__,__LINE__,device,count,free/1.e9,total/1.e9);
+#endif
 
+    HYPRE_Int ret = HYPRE_Init();
+
+#ifdef HAVE_CUDA
     hypre_HandleDefaultExecPolicy(hypre_handle()) = HYPRE_EXEC_DEVICE;
     hypre_HandleSpgemmUseCusparse(hypre_handle()) = 0;
 #endif


### PR DESCRIPTION
This is code that used to be in Hypre but they removed it. When multiple GPUs per node were used, mini app was assigning all work to GPU 0 on a node causing terrible performance. Here's the fix.

1) Basically, we figure out which ranks have a shared memory communicator via MPI_Comm_split_type.
2) We then do an Allreduce to count the number of nodes. 
3) Then the rank (in the shared communicator) is modded with the min of device count and the nprocs(global)/nnodes. This gives the device id to assign to cudaSetDevice.